### PR TITLE
Anti-Bias Randomness, Machine-Agnostic Bistro Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Source/Externals/.packman/*
 Media
 Tools/.packman
 Tests/data
+Scenes/
+Samples/

--- a/Source/Mogwai/Data/bistroConfig.py
+++ b/Source/Mogwai/Data/bistroConfig.py
@@ -48,7 +48,7 @@ def render_graph_DefaultRenderGraph():
 m.addGraph(render_graph_DefaultRenderGraph())
 
 # Scene
-m.loadScene('C:/Users/gifty/Downloads/Bistro_v5_1/BistroInterior.fbx')
+m.loadScene('../../../Scenes/Bistro_v5_1/BistroInterior.fbx')
 m.scene.renderSettings = SceneRenderSettings(useEnvLight=True, useAnalyticLights=True, useEmissiveLights=True)
 m.scene.cameraSpeed = 1.0
 
@@ -65,4 +65,3 @@ t.framerate = 0
 # Frame Capture
 fc.outputDir = '.'
 fc.baseFilename = 'Mogwai'
-

--- a/Source/RenderPasses/ExampleBlitPass/ExampleBlitPass.cpp
+++ b/Source/RenderPasses/ExampleBlitPass/ExampleBlitPass.cpp
@@ -27,6 +27,7 @@
  **************************************************************************/
 #include "ExampleBlitPass.h"
 #include <filesystem>
+#include <cstdlib>
 
 const ChannelList ExampleBlitPass::kGBufferChannels =
 {
@@ -169,7 +170,9 @@ void ExampleBlitPass::execute(RenderContext* pRenderContext, const RenderData& r
         mpPass->execute(pRenderContext, mpFbo);
 
         if (capturing) {
-            if (clock() - lastCaptureTime > captureInterval)
+            float antiBias = 0.9f + static_cast <float> (rand()) /( static_cast <float> (RAND_MAX/(0.2f)));
+
+            if (clock() - lastCaptureTime > (captureInterval * antiBias))
             {
                 dumpFormat = Falcor::Bitmap::FileFormat::ExrFile;
                 std::string fileEnding = dumpFormat == Falcor::Bitmap::FileFormat::PngFile ? ".png" : ".exr";
@@ -204,7 +207,7 @@ void ExampleBlitPass::execute(RenderContext* pRenderContext, const RenderData& r
                 emissive->captureToFile(0, 0, emissiveFile.string(), dumpFormat);
                 viewDirsOut->captureToFile(0, 0, viewFile.string(), dumpFormat);
                 viewNormalsOut->captureToFile(0, 0, normalFile.string(), dumpFormat);
-                
+
                 for (int i = 0; i < sizeof(dumpRates)/sizeof(dumpRates[0]); i++)
                 {
                     commandList5->RSSetShadingRate(dumpRates[i], nullptr);


### PR DESCRIPTION
One can use any folder in the computer for the orca scenes, by creating an hyperlink in the root directory of this repo called "Scenes".

Rnadomness prevents training with scene bias while we're using the bistro camera.